### PR TITLE
Add MacOS publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  publish:
+  publish-windows:
     runs-on: windows-latest
     permissions:
       contents: write
@@ -20,6 +20,21 @@ jobs:
       - uses: 'paramsinghvc/gh-action-bump-version@master'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: yarn publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  publish-macos:
+    runs-on: macos-latest
+    permissions:
+      contents: write
+      deployments: write
+    steps:
+      - run: git config --global core.autocrlf false
+      - uses: actions/checkout@v4
+      - uses: volta-cli/action@v4
+      - run: yarn install
+      - run: yarn lint
+      - run: yarn run typecheck
       - run: yarn publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Didn't create an issue.

@lukasbach 

I noticed there was no MacOS release being created. I ran Pensieve locally though so I believe this will enable the release to be cut. Its been a long time since I've touched Electron though so it may be more complicated.